### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/tmrts/flamingo.png?label=ready&title=Ready)](https://waffle.io/tmrts/flamingo)
 # Flamingo
 
 [![Travis](https://travis-ci.org/tmrts/flamingo.svg?branch=master)](https://travis-ci.org/tmrts/flamingo) [![Coverage Status](https://coveralls.io/repos/tmrts/flamingo/badge.svg?branch=master&service=github)](https://coveralls.io/github/tmrts/flamingo?branch=master) [![GoDoc](https://godoc.org/github.com/tmrts/flamingo?status.png)](https://godoc.org/github.com/tmrts/flamingo)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/tmrts/flamingo

This was requested by a real person (user tmrts) on waffle.io, we're not trying to spam you.
